### PR TITLE
Show all wasm-pack output in build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ module.exports = {
 
 - README improvements.
 
+### 1.1.3
+
+- `snowpack build` now outputs same compilation logs as `snowpack dev`.
+
 ## Useful links
 
 [`wasm-pack`](https://rustwasm.github.io/wasm-pack/book/introduction.html)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@emily-curry/snowpack-plugin-wasm-pack",
   "description": "Snowpack plugin for rust using wasm-pack 🦀",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "plugin.js",
   "types": "plugin.d.ts",
   "files": [

--- a/plugin.ts
+++ b/plugin.ts
@@ -96,6 +96,13 @@ const snowpackPluginWASMPack: SnowpackPluginFactory<SnowPackPluginWASMPackOption
         wasmPackArgs,
         wasmPackCommandOptions,
       );
+      const { stdout, stderr } = wasmPackResult;
+      if (stderr) {
+        logger.error(stderr, { name: pluginName });
+      }
+      if (stdout) {
+        logger.info(stdout, { name: pluginName });
+      }
       exitCode = wasmPackResult.exitCode;
     } catch (e) {
       exitCode = e.exitCode;


### PR DESCRIPTION
Should close #2 by showing wasm-pack output in `build` output.